### PR TITLE
docker-compose.prd: mount photos ro by default

### DIFF
--- a/docker/docker-compose.prd.yml
+++ b/docker/docker-compose.prd.yml
@@ -36,7 +36,7 @@ services:
       REDIS_HOST: redis
       ALLOWED_HOSTS: '*'
     volumes:
-      - ../data/photos:/data/photos
+      - ../data/photos:/data/photos:ro
       - ../data/raw-photos-processed:/data/raw-photos-processed
       - ../data/cache:/data/cache
       - ../data/models:/data/models


### PR DESCRIPTION
Hi Damian! Thank you for the great work! I've been itchy about putting something like this together for a while.

Mount photos ro by default to guarantee that updating/running photonix on the existing library is safe.