### PR TITLE
ignore (skipping) invalid utf-8 sequences from exiftool

### DIFF
--- a/photonix/photos/utils/metadata.py
+++ b/photonix/photos/utils/metadata.py
@@ -13,7 +13,7 @@ class PhotoMetadata(object):
         self.data = {}
         try:
             # exiftool produces data such as MIME Type for non-photos too
-            result = Popen(['exiftool', path], stdout=PIPE, stdin=PIPE, stderr=PIPE).communicate()[0].decode('utf-8')
+            result = Popen(['exiftool', path], stdout=PIPE, stdin=PIPE, stderr=PIPE).communicate()[0].decode('utf-8', 'ignore')
         except UnicodeDecodeError:
             result = ''
         for line in str(result).split('\n'):


### PR DESCRIPTION
decode bytes result from exiftool while ignoring (skipping) invalid utf-8 sequences.

Some tags were found to contain invalid UTF-8 sequences (mostly invalid start byte errors). Ignoring these while decoding the exiftool output prevents downstream divide-by-zero errors. These in turn are caused by image width / height from metadata being zero (or None) because of skipped tag parsing.

Should the skipped characters cause invalid '<key> : <value>' lines these are caught and ignored by the line parsing that processes the exiftool output.