### PR TITLE
never crash when images contain identical subject tags (type Generic)

### DIFF
--- a/photonix/photos/utils/db.py
+++ b/photonix/photos/utils/db.py
@@ -152,7 +152,7 @@ def record_photo(path, library, inotify_event_type=None):
         for subject in metadata.get('Subject', '').split(','):
             subject = subject.strip()
             if subject:
-                tag = Tag.objects.create(library_id=library_id, name=subject, type="G")
+                tag, _ = Tag.objects.get_or_create(library_id=library_id, name=subject, type="G")
                 PhotoTag.objects.create(
                     photo=photo,
                     tag=tag,


### PR DESCRIPTION
Multiple images with identical 'Subject' tags caused unique key constraint violations when an identical Tag object was created.

This fix caused the Subject Tag itself to be created just once, and added to every photo that contains it.