### PR TITLE
Fix path cannot be set when creating new library

### DIFF
--- a/photonix/photos/management/commands/create_library.py
+++ b/photonix/photos/management/commands/create_library.py
@@ -16,7 +16,7 @@ User = get_user_model()
 class Command(BaseCommand):
     help = 'Create a library for a user'
 
-    def create_library(self, username, library_name):
+    def create_library(self, username, library_name, path):
         # Get user
         user = User.objects.get(username=username)
         # Create Library
@@ -27,8 +27,7 @@ class Command(BaseCommand):
             library=library,
             type='St',
             backend_type='Lo',
-            path='/data/photos/',
-            url='/photos/',
+            path=path,
         )
         library_user, _ = LibraryUser.objects.get_or_create(
             library=library,
@@ -36,12 +35,13 @@ class Command(BaseCommand):
             owner=True,
         )
 
-        print(f'Library "{library_name}" created successfully for user "{username}"')
+        print(f'Library "{library_name}" with path "{path}" created successfully for user "{username}"')
 
     def add_arguments(self, parser):
         # Positional arguments
-        parser.add_argument('username', nargs='+', type=str)
-        parser.add_argument('library_name', nargs='+', type=str)
+        parser.add_argument('username', type=str)
+        parser.add_argument('library_name', type=str)
+        parser.add_argument('--path', type=str, default='/data/photos')
 
     def handle(self, *args, **options):
-        self.create_library(options['username'][0], options['library_name'][0])
+        self.create_library(options['username'], options['library_name'], options['path'])

--- a/photonix/photos/management/commands/create_library.py
+++ b/photonix/photos/management/commands/create_library.py
@@ -37,11 +37,15 @@ class Command(BaseCommand):
 
         print(f'Library "{library_name}" with path "{path}" created successfully for user "{username}"')
 
+    def is_path_dir(path):
+        if os.path.isdir(path):
+            return path
+
     def add_arguments(self, parser):
         # Positional arguments
         parser.add_argument('username', type=str)
         parser.add_argument('library_name', type=str)
-        parser.add_argument('--path', type=str, default='/data/photos')
+        parser.add_argument('--path', type=self.is_path_dir, default='/data/photos')
 
     def handle(self, *args, **options):
         self.create_library(options['username'], options['library_name'], options['path'])

--- a/photonix/photos/management/commands/create_library.py
+++ b/photonix/photos/management/commands/create_library.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 from pathlib import Path
 
 from django.contrib.auth import get_user_model
@@ -37,9 +38,11 @@ class Command(BaseCommand):
 
         print(f'Library "{library_name}" with path "{path}" created successfully for user "{username}"')
 
-    def is_path_dir(path):
+    def is_path_dir(self, path):
         if os.path.isdir(path):
             return path
+        else:
+            raise argparse.ArgumentTypeError(f"{path} is not a valid folder")
 
     def add_arguments(self, parser):
         # Positional arguments


### PR DESCRIPTION
When using the manage.py interface to create new library, the path is fixed to be '/data/photos'.
Encountered it while created 2 additional libraries and finding out one path imported into the older library.
Also removed the multiple username and libraries arguments as the code only uses the first ones.
Added a check to make sure the path given is a valid folder.

Should fix issue #333.

Fingers crossed this gets approved before v0.21.0 🤞