### PR TITLE
Fix crashes in thumbnails generation

### DIFF
--- a/photonix/photos/utils/thumbnails.py
+++ b/photonix/photos/utils/thumbnails.py
@@ -4,7 +4,7 @@ import os
 import math
 from pathlib import Path
 
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, ImageFile
 import numpy as np
 
 from django.conf import settings
@@ -82,6 +82,7 @@ def get_thumbnail(photo_file=None, photo=None, width=256, height=256, crop='cove
 
     # Read base image and metadata
     input_path = photo_file.base_image_path
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
     im = Image.open(input_path)
 
     if im.mode != 'RGB':


### PR DESCRIPTION
While generating thumbnails for a big old photos library (~12k photos), encountered two distinct crashes in the thumbnail processor:

> 2021-09-03 13:26:20,750 INFO     Finished thumbnail processing batch
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/srv/photonix/photos/management/commands/thumbnail_processor.py", line 24, in worker
    generate_thumbnails_for_photo(task.subject_id, task)
  File "/srv/photonix/photos/utils/thumbnails.py", line 37, in generate_thumbnails_for_photo
    get_thumbnail(photo=photo, width=thumbnail[0], height=thumbnail[1], crop=thumbnail[2], quality=thumbnail[3], force_regenerate=True, force_accurate=thumbnail[5])
  File "/srv/photonix/photos/utils/thumbnails.py", line 100, in get_thumbnail
    im = srgbResize(im, (width, height), crop, Image.BICUBIC)
  File "/srv/photonix/photos/utils/thumbnails.py", line 196, in srgbResize
    arr = np.array(im, dtype=np.float32) / 255.0
TypeError: float() argument must be a string or a number, not 'JpegImageFile'

And also:
> Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/srv/photonix/photos/management/commands/thumbnail_processor.py", line 24, in worker
    generate_thumbnails_for_photo(task.subject_id, task)
  File "/srv/photonix/photos/utils/thumbnails.py", line 37, in generate_thumbnails_for_photo
    get_thumbnail(photo=photo, width=thumbnail[0], height=thumbnail[1], crop=thumbnail[2], quality=thumbnail[3], force_regenerate=True, force_accurate=thumbnail[5])
  File "/srv/photonix/photos/utils/thumbnails.py", line 94, in get_thumbnail
    im = im.rotate(-90, expand=True)
  File "/usr/local/lib/python3.8/site-packages/PIL/Image.py", line 2024, in rotate
    return self.transpose(ROTATE_270)
  File "/usr/local/lib/python3.8/site-packages/PIL/Image.py", line 2524, in transpose
    self.load()
  File "/usr/local/lib/python3.8/site-packages/PIL/ImageFile.py", line 274, in load
    raise_oserror(err_code)
  File "/usr/local/lib/python3.8/site-packages/PIL/ImageFile.py", line 67, in raise_oserror
    raise OSError(message + " when reading image file")
OSError: broken data stream when reading image file

Ran the thumbnail_processor a few times until I was left with 2 problematic images that generated those errors.
Each time a rescan of the images happened, another 2 tasks for those images were duplicated, I also had to manually run the thumbnail_processor, it seems to not restart like the object and face detection.

After seeing the 2 images files, it seems they are corrupted from a recovery attempt I've made some years ago (lost some data).
After searching for a solution and contemplating how to fix this, found this thread: https://github.com/python-pillow/Pillow/issues/3185
This flag will let Pillow read files even if they're corrupted/truncated (no EOI marker 0xffd9), so photonix can continue processing gracefully.

One can argue that maybe it's best to catch those exceptions and make:
1. Special handling in DB for those, to mark as 'completed with error' (e.g. 'ce').
2. A new error inside the UI for user notification.
But different formats can have different exceptions for those corrupted images, so requires more testing and fiddling before implementing something like this.