### PR TITLE
photonixapp/photonix#246: Fix typo in "persional" to "personal"

### DIFF
--- a/photonix/accounts/management/commands/create_admin_from_env.py
+++ b/photonix/accounts/management/commands/create_admin_from_env.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
             exit(1)
         else:
             user.set_password(password)
-            user.has_config_persional_info = True
+            user.has_config_personal_info = True
             user.save()
             print(f'User "{username}" created successfully and password set')
 

--- a/photonix/accounts/migrations/0002_crt_fld_has_config_persional_info.py
+++ b/photonix/accounts/migrations/0002_crt_fld_has_config_persional_info.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='user',
-            name='has_config_persional_info',
-            field=models.BooleanField(default=False, help_text='true if user has registered persional info?'),
+            name='has_config_personial_info',
+            field=models.BooleanField(default=False, help_text='true if user has registered personal info?'),
         ),
     ]

--- a/photonix/accounts/migrations/0005_fix_typo_personal.py
+++ b/photonix/accounts/migrations/0005_fix_typo_personal.py
@@ -1,0 +1,18 @@
+# Manually created by someone who has no idea what they are doing.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0004_alter_user_first_name'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='user',
+            old_name='has_config_personial_info',
+            new_name='has_config_personal_info',
+        ),
+    ]

--- a/photonix/accounts/models.py
+++ b/photonix/accounts/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 
 class User(UUIDModel, AbstractUser):
-    has_config_persional_info = models.BooleanField(default=False, help_text='true if user has registered persional info?')
+    has_config_personal_info = models.BooleanField(default=False, help_text='true if user has registered personal info?')
     has_created_library = models.BooleanField(default=False, help_text='true if user has created his library?')
     has_configured_importing = models.BooleanField(default=False, help_text='true if user has configured importing?')
     has_configured_image_analysis = models.BooleanField(default=False, help_text='true if user has configured image analysis?')

--- a/photonix/accounts/schema.py
+++ b/photonix/accounts/schema.py
@@ -23,7 +23,7 @@ class CreateUser(graphene.Mutation):
         password = graphene.String(required=True)
         password1 = graphene.String(required=True)
 
-    has_config_persional_info = graphene.Boolean()
+    has_config_personal_info = graphene.Boolean()
     user_id = graphene.ID()
     ok = graphene.Boolean()
 
@@ -38,10 +38,10 @@ class CreateUser(graphene.Mutation):
         else:
             user = User(username=username)
             user.set_password(password1)
-            user.has_config_persional_info = True
+            user.has_config_personal_info = True
             user.save()
         return CreateUser(
-            has_config_persional_info=user.has_config_persional_info,
+            has_config_personal_info=user.has_config_personal_info,
             ok=True, user_id=user.id)
 
 
@@ -77,7 +77,7 @@ class Query(graphene.ObjectType):
         demo = os.environ.get('DEMO', False)
         sample_data = os.environ.get('DEMO', False) or os.environ.get('SAMPLE_DATA', False)
 
-        if user and user.has_config_persional_info and \
+        if user and user.has_config_personal_info and \
             user.has_created_library and user.has_configured_importing and \
                 user.has_configured_image_analysis:
             return {
@@ -91,7 +91,7 @@ class Query(graphene.ObjectType):
                     'demo': demo,
                     'sample_data': sample_data,
                     'first_run': True,
-                    'form': 'has_config_persional_info'}
+                    'form': 'has_config_personal_info'}
             if not user.has_created_library:
                 return {
                     'demo': demo,

--- a/photonix/photos/management/commands/import_demo_photos.py
+++ b/photonix/photos/management/commands/import_demo_photos.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         try:
             user = User.objects.create_user(
                 username='demo', email='demo@photonix.org', password='demo')
-            user.has_config_persional_info = True
+            user.has_config_personal_info = True
             user.has_created_library = True
             user.has_configured_importing = True
             user.has_configured_image_analysis = True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,7 +13,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     username = 'test'
     email = 'test@example.com'
-    has_config_persional_info = True
+    has_config_personal_info = True
     has_created_library = True
     has_configured_importing = True
     has_configured_image_analysis = True

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -760,7 +760,7 @@ class TestGraphQLOnboarding(unittest.TestCase):
         mutation = """
             mutation ($username: String!,$password:String!,$password1:String!) {
                 createUser(username: $username,password:$password,password1:$password1) {
-                    hasConfigpersonalInfo
+                    hasConfigPersonalInfo
                     userId
                 }
             }
@@ -769,7 +769,7 @@ class TestGraphQLOnboarding(unittest.TestCase):
             mutation, {'username': 'demo', 'password': 'demo12345', 'password1': 'demo12345'})
         data = get_graphql_content(response)
         assert response.status_code == 200
-        assert data['data']['createUser']['hasConfigpersonalInfo']
+        assert data['data']['createUser']['hasConfigPersonalInfo']
         assert User.objects.all().count() == 1
         assert User.objects.first().has_config_personal_info
         self.assertFalse(User.objects.first().has_created_library)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -755,12 +755,12 @@ class TestGraphQLOnboarding(unittest.TestCase):
         data = get_graphql_content(response)
         assert response.status_code == 200
         assert data['data']['environment']['firstRun']
-        assert data['data']['environment']['form'] == 'has_config_persional_info'
+        assert data['data']['environment']['form'] == 'has_config_personal_info'
         self.assertFalse(User.objects.all().count())
         mutation = """
             mutation ($username: String!,$password:String!,$password1:String!) {
                 createUser(username: $username,password:$password,password1:$password1) {
-                    hasConfigPersionalInfo
+                    hasConfigpersonalInfo
                     userId
                 }
             }
@@ -769,9 +769,9 @@ class TestGraphQLOnboarding(unittest.TestCase):
             mutation, {'username': 'demo', 'password': 'demo12345', 'password1': 'demo12345'})
         data = get_graphql_content(response)
         assert response.status_code == 200
-        assert data['data']['createUser']['hasConfigPersionalInfo']
+        assert data['data']['createUser']['hasConfigpersonalInfo']
         assert User.objects.all().count() == 1
-        assert User.objects.first().has_config_persional_info
+        assert User.objects.first().has_config_personal_info
         self.assertFalse(User.objects.first().has_created_library)
         self.assertFalse(response.wsgi_request.user.username)
         mutation = """
@@ -877,7 +877,7 @@ class TestGraphQLOnboarding(unittest.TestCase):
         self.assertFalse(library.classification_location_enabled)
         self.assertTrue(
             User.objects.filter(
-                username='demo', has_config_persional_info=True,
+                username='demo', has_config_personal_info=True,
                 has_created_library=True, has_configured_importing=True,
                 has_configured_image_analysis=True).exists()
         )

--- a/ui/src/components/Login.js
+++ b/ui/src/components/Login.js
@@ -81,7 +81,7 @@ const Login = (props) => {
     authUser,
     { data: authData, loading: authLoading, error: authError },
   ] = useMutation(AUTH_USER)
-  if (envData && envData.environment.form === 'has_config_persional_info') {
+  if (envData && envData.environment.form === 'has_config_personal_info') {
     return <Redirect to="/onboarding" />
   }
   if (envData && envData.environment.form === 'has_created_library') {

--- a/ui/src/graphql/onboarding.js
+++ b/ui/src/graphql/onboarding.js
@@ -17,7 +17,7 @@ mutation (
    $username: String!,$password:String!,$password1:String!
    ) {
     createUser(username: $username,password:$password,password1:$password1) {
-        hasConfigPersionalInfo
+        hasConfigpersonalInfo
         userId
     }
 }

--- a/ui/src/graphql/onboarding.js
+++ b/ui/src/graphql/onboarding.js
@@ -17,7 +17,7 @@ mutation (
    $username: String!,$password:String!,$password1:String!
    ) {
     createUser(username: $username,password:$password,password1:$password1) {
-        hasConfigpersonalInfo
+        hasConfigPersonalInfo
         userId
     }
 }


### PR DESCRIPTION
This PR (my first to a Django project, I think!) attempts to fix the typo in model storage `user.has_config_persional_info` to `user.has_config_personal_info`.

Noticed this as part of #246 - I don't expect this to fix the issue, but it can at least eliminate the typo as cause of the wrong behaviour in that issue.

Please review the migration proposed here thoroughly!

🖥️ 🐕 