### PR TITLE
Run the containers without root

### DIFF
--- a/docker/Dockerfile.prd
+++ b/docker/Dockerfile.prd
@@ -92,10 +92,11 @@ RUN rm -rf \
 
 
 FROM ${ARCH}python:3.8.12-slim-bullseye
+ARG UID=2000
+ARG GID=2000
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        cron \
         dcraw \
         file \
         libatlas3-base \
@@ -123,6 +124,7 @@ COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /srv/ui/build /srv/ui/build
 
+
 WORKDIR /srv
 
 # Copy over the code
@@ -136,14 +138,15 @@ COPY ui/public /srv/ui/public
 COPY system /srv/system
 COPY system/supervisord.conf /etc/supervisord.conf
 
-# Copy crontab
-COPY system/cron.d /etc/cron.d/
-RUN chmod 0644 /etc/cron.d/*
-
 ENV PYTHONPATH /srv
 ENV TF_CPP_MIN_LOG_LEVEL 3
 
 RUN DJANGO_SECRET_KEY=test python photonix/manage.py collectstatic --noinput --link
+
+RUN groupadd -g $GID photonix
+RUN useradd -u $UID -g $GID photonix
+RUN chown -R photonix:photonix /srv /var/lib/nginx /var/log/nginx /var/run /run
+USER photonix
 
 CMD ./system/run.sh
 

--- a/docker/docker-compose.prd.yml
+++ b/docker/docker-compose.prd.yml
@@ -2,23 +2,26 @@ version: '3'
 
 services:
   postgres:
+    user: "70:70"
     container_name: photonix-postgres
     image: postgres:11.1-alpine
-    ports:
-      - '5432:5432'
     environment:
       POSTGRES_DB: photonix
       POSTGRES_PASSWORD: password
     volumes:
       - ../data/db:/var/lib/postgresql/data
+    depends_on:
+      - init
 
   redis:
+    user: "999:999"
     container_name: photonix-redis
     image: redis:6.2.2
-    ports:
-      - '6379:6379'
+    depends_on:
+      - init
 
   photonix:
+    user: "2000:2000"
     container_name: photonix
     # image: photonixapp/photonix:latest
     image: photonix
@@ -43,3 +46,5 @@ services:
     links:
       - postgres
       - redis
+    depends_on:
+      - init

--- a/system/nginx_prd.conf
+++ b/system/nginx_prd.conf
@@ -1,4 +1,3 @@
-user  root;
 worker_processes    8;
 daemon off;
 

--- a/system/supervisord.conf
+++ b/system/supervisord.conf
@@ -30,7 +30,7 @@ stderr_logfile_maxbytes=0
 stdout_logfile_maxbytes=0
 
 [program:cron]
-command = /bin/bash -c "declare -p | grep -Ev '^declare -[[:alpha:]]*r' > /run/supervisord.env && /usr/sbin/cron -f -L 15"
+command = /bin/bash -c "declare -p | grep -Ev '^declare -[[:alpha:]]*r' > /run/supervisord.env && . /run/supervisord.env; while [ 1 ]; do python /srv/photonix/manage.py retrain_face_similarity_index; sleep 300; done"
 stderr_logfile=/dev/stderr
 stdout_logfile=/dev/stdout
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
This should improve potential exposure quite a bit by only requiring root in a busybox init container to set the directories up. 

Since I've only changed the production configs this won't work alongside a dev install if you're switching between the two. Let me know if you consider this worthwhile and I'll get that working too.