### PR TITLE
fix: prevent map from showing photos from other libraries

### DIFF
--- a/ui/src/containers/BrowseContainer.js
+++ b/ui/src/containers/BrowseContainer.js
@@ -196,8 +196,8 @@ const BrowseContainer = (props) => {
   } = useQuery(GET_MAP_PHOTOS, {
     variables: {
       filters: searchStr,
-      skip: !user,
     },
+    skip: !user || !searchStr || !searchStr.includes('library_id:'),
   })
   if (mapPhotosError) console.log(mapPhotosError)
 


### PR DESCRIPTION
## Summary
Fixes #367

The map photos query was potentially loading before the library filter was properly set, causing photos from all user-accessible libraries to appear on the map instead of just the currently selected library.

## The Bug
The original issue reported "private images appear on the map" — after investigation, there is no user-facing private/hidden photo feature in the codebase. The reporter likely had **multiple libraries** and was seeing photos from Library A appearing when viewing Library B's map.

## Root Cause
In `BrowseContainer.js`, the `useQuery` for map photos had two issues:
1. `skip: !user` was incorrectly placed inside `variables` instead of as a query option
2. No guard against running the query before `searchStr` (which contains `library_id:`) was populated

## Fix
```javascript
// Before (buggy):
useQuery(GET_MAP_PHOTOS, {
  variables: {
    filters: searchStr,
    skip: !user,  // ← Wrong! This is sent as a variable, not used as skip option
  },
})

// After (fixed):
useQuery(GET_MAP_PHOTOS, {
  variables: {
    filters: searchStr,
  },
  skip: !user || !searchStr || !searchStr.includes('library_id:'),
})
```

This ensures the map query only runs after:
- User is logged in
- Library filter string is populated
- Library ID is present in the filter

## Testing
- Verify map only shows photos from currently selected library
- Switch libraries and confirm map updates to show only that library's photos
- Check no cross-library photo leakage occurs