### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take the security of Photonix seriously. If you discover a security vulnerability, please report it responsibly.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email us at:
+
+📧 **[security@epixstudios.co.uk](mailto:security@epixstudios.co.uk)**
+
+### What to include
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any potential impact you've identified
+- Your name/handle for credit (optional)
+
+### What to expect
+
+- **Acknowledgement:** We will acknowledge receipt of your report within **48 hours**.
+- **Assessment:** We will investigate and provide an initial assessment within **7 days**.
+- **Resolution:** We aim to release a fix within **30 days** of confirmation, depending on complexity.
+- **Disclosure:** We will coordinate with you on public disclosure timing.
+
+### Safe harbour
+
+We consider security research conducted in good faith to be authorised. We will not pursue legal action against researchers who:
+
+- Act in good faith to avoid privacy violations, data destruction, or service disruption
+- Only interact with accounts they own or with explicit permission
+- Report vulnerabilities through the process outlined above
+- Allow reasonable time for resolution before public disclosure
+
+## Credit
+
+We are happy to credit security researchers who report valid vulnerabilities, unless they prefer to remain anonymous.
+
+Thank you for helping keep Photonix and its users safe! 🔐


### PR DESCRIPTION
## Summary
Closes #433
Closes #434

Adds a standard `SECURITY.md` document providing a clear responsible disclosure process for reporting security vulnerabilities.

## Details

- Security reports should be emailed to **security@epixstudios.co.uk**
- Includes response timeline commitments (48h ack, 7-day assessment, 30-day fix)
- Safe harbour clause for good-faith security researchers
- Credit offered to reporters

## Context

Issues #433 and #434 were opened by security researchers who found vulnerabilities but had no way to report them privately. This policy gives them (and future reporters) a clear path.

GitHub will also automatically surface this file in the Security tab of the repository.