### PR TITLE
Remove GHA cache from test job to fix prod build times

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,8 +25,6 @@ jobs:
           file: ./docker/Dockerfile.dev
           load: true
           tags: photonix-test:latest
-          cache-from: type=gha,scope=test
-          cache-to: type=gha,mode=max,scope=test
       -
         name: Start Redis
         run: docker run -d --name redis --network host redis:8-alpine


### PR DESCRIPTION
## Summary
- Remove `cache-from`/`cache-to` from the test job's Docker build step
- The test + prod caches combined exceed GitHub's 10GB cache limit, causing prod cache entries to be evicted (LRU)
- This forces the multi-platform prod build to rebuild from scratch (~39 min instead of ~1 min when cached)
- The test cache provides minimal benefit — the image is ephemeral and code layers change every push

## Test plan
- [ ] Verify test job still builds and runs successfully (just without cache)
- [ ] Verify prod build-and-push hits cache on subsequent runs (should drop from ~39 min to ~1 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)